### PR TITLE
feat: store acquire token as promise for multi access

### DIFF
--- a/packages/vue-auth-msal/src/composables/useMsalAuthentication.ts
+++ b/packages/vue-auth-msal/src/composables/useMsalAuthentication.ts
@@ -28,109 +28,108 @@ export function useMsalAuthentication(): MsalAuthResult {
 
   const loginInteractionType = interactionType
   const isInProgress = ref<boolean>(false)
+  const storedAcquireTokenPromise = ref<Promise<void> | null>(null)
   const result = ref<AuthenticationResult | null>(null)
   const error = ref<AuthError | null>(null)
 
-  const acquireToken = async (requestOverride?: PopupRequest | RedirectRequest | SilentRequest): Promise<void> => {
+  const acquireTokenPromise = async (requestOverride?: PopupRequest | RedirectRequest | SilentRequest): Promise<void> => {
     logger.verbose(`useMsalAuthentication.acquireToken():Called`)
 
-    if (!isInProgress.value) {
-      // Lock
-      isInProgress.value = true
-
-      // Process for handleRedirectPromise()
-      if (inProgress.value === InteractionStatus.HandleRedirect) {
-        logger.verbose(`useMsalAuthentication.acquireToken():handleRedirectPromise triggered`)
-        try {
-          const response = await instance.handleRedirectPromise()
-          if (response) {
-            logger.verbose(
-              `useMsalAuthentication.acquireToken():handleRedirectPromise success response: ${JSON.stringify(
-                response,
-              )}`,
-            )
-            result.value = response
-            error.value = null
-          }
-        } catch (e) {
-          logger.verbose(`useMsalAuthentication.acquireToken():handleRedirectPromise error: ${JSON.stringify(e)}`)
-          result.value = null
-          error.value = e as AuthError
-        }
-        isInProgress.value = false
-      }
-      // Process for acquireToken()
-      else if (inProgress.value === InteractionStatus.None) {
-        const tokenRequest = requestOverride || loginRequest
-        logger.verbose(
-          `useMsalAuthentication.acquireToken():acquireTokenSilent triggered with ${JSON.stringify(tokenRequest)}`,
-        )
-        try {
-          const response = await instance.acquireTokenSilent(tokenRequest)
+    // Process for handleRedirectPromise()
+    if (inProgress.value === InteractionStatus.HandleRedirect) {
+      logger.verbose(`useMsalAuthentication.acquireToken():handleRedirectPromise triggered`)
+      try {
+        const response = await instance.handleRedirectPromise()
+        if (response) {
           logger.verbose(
-            `useMsalAuthentication.acquireToken():acquireTokenSilent success response: ${JSON.stringify(response)}`,
+            `useMsalAuthentication.acquireToken():handleRedirectPromise success response: ${JSON.stringify(
+              response,
+            )}`,
           )
           result.value = response
           error.value = null
-        } catch (e: any) {
-          logger.verbose(`useMsalAuthentication.acquireToken():acquireTokenSilent error = ${JSON.stringify(e)}`)
-          // Try Login (Popup or Redirect) when no account error
-          if (
-            e instanceof InteractionRequiredAuthError ||
-            (e instanceof BrowserAuthError &&
-              (e as BrowserAuthError).errorCode === BrowserAuthErrorMessage.noAccountError.code &&
-              instance.getAllAccounts().length == 0)
-          ) {
-            logger.verbose(
-              `useMsalAuthentication.acquireToken():interactive login triggered with ${JSON.stringify(tokenRequest)}`,
-            )
-            if (loginInteractionType === InteractionType.Popup) {
-              await instance
-                .loginPopup(tokenRequest)
-                .then((response) => {
-                  logger.verbose(
-                    `useMsalAuthentication.acquireToken():loginPopup success response: ${JSON.stringify(response)}`,
-                  )
-                  result.value = response
-                  error.value = null
-                })
-                .catch((e) => {
-                  result.value = null
-                  error.value = e as AuthError
-                  if (
-                    e instanceof BrowserAuthError &&
-                    (e as BrowserAuthError).errorCode === BrowserAuthErrorMessage.userCancelledError.code
-                  ) {
-                    logger.info(`useMsal.login():loginPopup user_cancelled`)
-                  } else {
-                    logger.error(`useMsal.login():loginPopup error: ${JSON.stringify(e)}`)
-                  }
-                })
-            } else {
-              await instance.loginRedirect(tokenRequest).catch((e) => {
-                logger.verbose(`useMsalAuthentication.acquireToken():loginRedirect error: ${JSON.stringify(e)}`)
+        }
+      } catch (e) {
+        logger.verbose(`useMsalAuthentication.acquireToken():handleRedirectPromise error: ${JSON.stringify(e)}`)
+        result.value = null
+        error.value = e as AuthError
+      }
+    }
+    // Process for acquireToken()
+    else if (inProgress.value === InteractionStatus.None) {
+      const tokenRequest = requestOverride || loginRequest
+      logger.verbose(
+        `useMsalAuthentication.acquireToken():acquireTokenSilent triggered with ${JSON.stringify(tokenRequest)}`,
+      )
+      try {
+        const response = await instance.acquireTokenSilent(tokenRequest)
+        logger.verbose(
+          `useMsalAuthentication.acquireToken():acquireTokenSilent success response: ${JSON.stringify(response)}`,
+        )
+        result.value = response
+        error.value = null
+      } catch (e: any) {
+        logger.verbose(`useMsalAuthentication.acquireToken():acquireTokenSilent error = ${JSON.stringify(e)}`)
+        // Try Login (Popup or Redirect) when no account error
+        if (
+          e instanceof InteractionRequiredAuthError ||
+          (e instanceof BrowserAuthError &&
+            (e as BrowserAuthError).errorCode === BrowserAuthErrorMessage.noAccountError.code &&
+            instance.getAllAccounts().length == 0)
+        ) {
+          logger.verbose(
+            `useMsalAuthentication.acquireToken():interactive login triggered with ${JSON.stringify(tokenRequest)}`,
+          )
+          if (loginInteractionType === InteractionType.Popup) {
+            await instance
+              .loginPopup(tokenRequest)
+              .then((response) => {
+                logger.verbose(
+                  `useMsalAuthentication.acquireToken():loginPopup success response: ${JSON.stringify(response)}`,
+                )
+                result.value = response
+                error.value = null
+              })
+              .catch((e) => {
                 result.value = null
                 error.value = e as AuthError
+                if (
+                  e instanceof BrowserAuthError &&
+                  (e as BrowserAuthError).errorCode === BrowserAuthErrorMessage.userCancelledError.code
+                ) {
+                  logger.info(`useMsal.login():loginPopup user_cancelled`)
+                } else {
+                  logger.error(`useMsal.login():loginPopup error: ${JSON.stringify(e)}`)
+                }
               })
-            }
-          }
-          // Other error cases
-          else {
-            result.value = null
-            error.value = e as AuthError
+          } else {
+            await instance.loginRedirect(tokenRequest).catch((e) => {
+              logger.verbose(`useMsalAuthentication.acquireToken():loginRedirect error: ${JSON.stringify(e)}`)
+              result.value = null
+              error.value = e as AuthError
+            })
           }
         }
+        // Other error cases
+        else {
+          result.value = null
+          error.value = e as AuthError
+        }
       }
-
-      // Unlock
-      isInProgress.value = false
     }
 
     logger.verbose(`useMsalAuthentication.acquireToken():Returned`)
+    isInProgress.value = false
     return
   }
 
-  //await acquireToken()
+  const acquireToken = async (requestOverride?: PopupRequest | RedirectRequest | SilentRequest): Promise<void> => {
+    if (!isInProgress.value || !storedAcquireTokenPromise.value) {
+      isInProgress.value = true
+      storedAcquireTokenPromise.value = acquireTokenPromise(requestOverride)
+    }
+    return storedAcquireTokenPromise.value
+  }
 
   return {
     acquireToken: acquireToken,


### PR DESCRIPTION
Hey,

I had some trouble with concurrent calls of `acquireToken()`. This results from multiple api calls done from my Vue app simultanious. First, I was confused why some of the calls of `acquireToken` not updating the result value until I found out, the method blocks itself from being called while already called and not finished.
I figured out a workaround by saving the promise what results in getting exactly the same promise while not finished processing. I think this workaround should be the default behavior because it's hard to figure out why `useMsalAuthentication()`s `result` is `undefined` without a deep-dive into the source code.

Cheers!